### PR TITLE
ENH: use universal HTML for html mimebundle

### DIFF
--- a/altair_saver/savers/tests/test_html.py
+++ b/altair_saver/savers/tests/test_html.py
@@ -13,6 +13,9 @@ from altair_saver._utils import internet_connected
 from altair_saver.savers import HTMLSaver
 
 
+CDN_URL = "https://cdn.jsdelivr.net"
+
+
 @pytest.fixture(scope="module")
 def internet_ok():
     return internet_connected()
@@ -51,16 +54,41 @@ def get_testcases() -> Iterator[Tuple[str, Dict[str, Any]]]:
 @pytest.mark.parametrize("inline", [True, False])
 @pytest.mark.parametrize("embed_options", [None, {"theme": "dark"}])
 @pytest.mark.parametrize("case, data", get_testcases())
-def test_html_saver(
+def test_html_save(
     case: str, data: Dict[str, Any], embed_options: Optional[dict], inline: bool
 ) -> None:
     saver = HTMLSaver(data["vega-lite"], inline=inline, embed_options=embed_options)
-    bundle = saver.mimebundle("html")
-    html = bundle.popitem()[1]
+    fp = io.StringIO()
+    saver.save(fp, "html")
+    html = fp.getvalue()
     assert isinstance(html, str)
     assert html.strip().startswith("<!DOCTYPE html>")
     assert json.dumps(data["vega-lite"]) in html
     assert f"const embedOpt = {json.dumps(embed_options or {})}" in html
+
+    if inline:
+        assert CDN_URL not in html
+    else:
+        assert CDN_URL in html
+
+
+@pytest.mark.parametrize("embed_options", [None, {"theme": "dark"}])
+@pytest.mark.parametrize("case, data", get_testcases())
+def test_html_mimebundle(
+    case: str, data: Dict[str, Any], embed_options: Optional[dict],
+) -> None:
+    saver = HTMLSaver(data["vega-lite"], embed_options=embed_options)
+    bundle = saver.mimebundle("html")
+    assert bundle.keys() == {"text/html"}
+
+    html = bundle["text/html"]
+    assert isinstance(html, str)
+
+    assert html.strip().startswith("<div")
+    assert json.dumps(data["vega-lite"]) in html
+    assert json.dumps(embed_options or {}) in html
+
+    assert CDN_URL in html
 
 
 def test_bad_format() -> None:
@@ -71,7 +99,7 @@ def test_bad_format() -> None:
 
 @pytest.mark.parametrize("case, data", get_testcases())
 @pytest.mark.parametrize("inline", [True, False])
-def test_html_rendering(
+def test_html_save_rendering(
     provider: Provider,
     driver: WebDriver,
     case: str,
@@ -82,20 +110,14 @@ def test_html_rendering(
     if not (inline or internet_ok):
         pytest.xfail("Internet connection not available")
     saver = HTMLSaver(data["vega-lite"], inline=inline)
-    bundle = saver.mimebundle("html")
-    html = bundle.popitem()[1]
-    assert isinstance(html, str)
-
-    cdn_url = "https://cdn.jsdelivr.net"
-    if inline:
-        assert cdn_url not in html
-    else:
-        assert cdn_url in html
+    fp = io.StringIO()
+    saver.save(fp, "html")
+    html = fp.getvalue()
 
     resource = provider.create(content=html, extension="html")
     driver.set_window_size(800, 600)
     driver.get(resource.url)
-    element = driver.find_element_by_id("vis")
+    element = driver.find_element_by_class_name("vega-visualization")
 
     png = driver.get_screenshot_as_png()
     im = Image.open(io.BytesIO(png))
@@ -108,4 +130,48 @@ def test_html_rendering(
     im_expected = Image.open(io.BytesIO(data["png"]))
     assert abs(im.size[0] - im_expected.size[0]) < 40
     assert abs(im.size[1] - im_expected.size[1]) < 40
-    #
+
+
+@pytest.mark.parametrize("requirejs", [True, False])
+@pytest.mark.parametrize("case, data", get_testcases())
+def test_html_mimebundle_rendering(
+    provider: Provider,
+    driver: WebDriver,
+    case: str,
+    data: Dict[str, Any],
+    requirejs: bool,
+    internet_ok: bool,
+) -> None:
+    if not internet_ok:
+        pytest.xfail("Internet connection not available")
+    saver = HTMLSaver(data["vega-lite"])
+    bundle = saver.mimebundle("html")
+    html = bundle["text/html"]
+    assert isinstance(html, str)
+
+    if requirejs:
+        html = f"""<!DOCTYPE html>
+        <html>
+          <head><script src="{CDN_URL}/npm/requirejs@2.3.6"></script></head>
+          <body>{html}</body>
+        </html>
+        """
+    else:
+        html = f"<html>{html}</html>"
+
+    resource = provider.create(content=html, extension="html")
+    driver.set_window_size(800, 600)
+    driver.get(resource.url)
+    element = driver.find_element_by_class_name("vega-visualization")
+
+    png = driver.get_screenshot_as_png()
+    im = Image.open(io.BytesIO(png))
+    left = element.location["x"]
+    top = element.location["y"]
+    right = element.location["x"] + element.size["width"]
+    bottom = element.location["y"] + element.size["height"]
+    im = im.crop((left, top, right, bottom))
+
+    im_expected = Image.open(io.BytesIO(data["png"]))
+    assert abs(im.size[0] - im_expected.size[0]) < 40
+    assert abs(im.size[1] - im_expected.size[1]) < 40

--- a/altair_saver/tests/test_core.py
+++ b/altair_saver/tests/test_core.py
@@ -128,15 +128,12 @@ def test_infer_mode(spec: JSONDict) -> None:
     assert vl_svg == vg_svg
 
 
-@pytest.mark.parametrize("inline", [True, False])
 @pytest.mark.parametrize("embed_options", [{}, {"padding": 20}])
-def test_embed_options_render_html(
-    spec: JSONDict, inline: bool, embed_options: JSONDict
-) -> None:
+def test_embed_options_render_html(spec: JSONDict, embed_options: JSONDict) -> None:
     with alt.renderers.set_embed_options(**embed_options):
-        bundle = render(spec, "html", inline=inline)
+        bundle = render(spec, "html")
     html = bundle.popitem()[1]
-    assert f"const embedOpt = {json.dumps(embed_options or {})};" in html
+    assert json.dumps(embed_options or {}) in html
 
 
 @pytest.mark.parametrize("inline", [True, False])


### PR DESCRIPTION
When using the ``render()`` method, this automatically switches to the same Universal HTML approach as Altair's default renderer, so that the output will work correctly when embedded in a variety of notebook frontends.