### PR TITLE
ENH: support, document, and test scale_factor in selenium saver

### DIFF
--- a/altair_saver/_core.py
+++ b/altair_saver/_core.py
@@ -128,6 +128,9 @@ def save(
     offline : bool (optional)
         For method="selenium", whether to save charts in offline mode (default=True). If
         false, saving charts will require a web connection to load Javascript from CDN.
+    scale_factor : integer (optional)
+        For method="selenium", scale saved image by this factor (default=1). This parameter
+        value is overridden by embed_options["scaleFactor"] when both are specified.
     **kwargs :
         Additional keyword arguments are passed to Saver initialization.
     """

--- a/altair_saver/savers/_selenium.py
+++ b/altair_saver/savers/_selenium.py
@@ -44,7 +44,7 @@ const format = arguments[2];
 const done = arguments[3];
 
 if (format === 'vega') {
-    if (embedOpt['mode'] === 'vega-lite') {
+    if (embedOpt.mode === 'vega-lite') {
         vegaLite = (typeof vegaLite === "undefined") ? vl : vegaLite;
         try {
             const compiled = vegaLite.compile(spec);
@@ -59,7 +59,7 @@ if (format === 'vega') {
 vegaEmbed('#vis', spec, embedOpt).then(function(result) {
     if (format === 'png') {
         result.view
-            .toCanvas()
+            .toCanvas(embedOpt.scaleFactor || 1)
             .then(function(canvas){return canvas.toDataURL('image/png');})
             .then(result => done({result}))
             .catch(function(err) {
@@ -68,7 +68,7 @@ vegaEmbed('#vis', spec, embedOpt).then(function(result) {
             });
     } else if (format === 'svg') {
         result.view
-            .toSVG()
+            .toSVG(embedOpt.scaleFactor || 1)
             .then(result => done({result}))
             .catch(function(err) {
                 console.error(err);
@@ -165,12 +165,16 @@ class SeleniumSaver(Saver):
         driver_timeout: int = 20,
         webdriver: Optional[Union[str, WebDriver]] = None,
         offline: bool = True,
+        scale_factor: Optional[float] = 1,
     ) -> None:
         self._driver_timeout = driver_timeout
         self._webdriver = (
             self._select_webdriver(driver_timeout) if webdriver is None else webdriver
         )
         self._offline = offline
+        if scale_factor != 1:
+            embed_options = embed_options or {}
+            embed_options.setdefault("scaleFactor", scale_factor)
         super().__init__(
             spec=spec,
             mode=mode,

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,3 +30,6 @@ ignore_missing_imports = True
 
 [mypy-setuptools.*]
 ignore_missing_imports = True
+
+[mypy-xml.dom.*]
+ignore_missing_imports = True


### PR DESCRIPTION
The 0.2 release supports ``scale_factor`` for ``method="selenium"``. This PR restores that keyword, and makes it interact correctly with the new ``embed_options`` keyword.