### PR TITLE
BUG: fix node path detection

### DIFF
--- a/altair_saver/savers/_node.py
+++ b/altair_saver/savers/_node.py
@@ -25,7 +25,7 @@ def npm_bin(global_: bool) -> str:
     cmd = [npm, "bin"]
     if global_:
         cmd.append("--global")
-    return check_output_with_stderr(cmd).decode()
+    return check_output_with_stderr(cmd).decode().strip()
 
 
 @functools.lru_cache(16)


### PR DESCRIPTION
In newer npm releases, the returned path includes a newline, which was preventing ``NodeSaver`` from correctly finding binaries.