### PR TITLE
Make altair-saver compatible with pathlib.Path

### DIFF
--- a/altair_saver/_core.py
+++ b/altair_saver/_core.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from pathlib import Path
 from typing import Any, Dict, IO, Iterable, Optional, Set, Type, Union
 import warnings
 
@@ -73,7 +74,7 @@ def _select_saver(
 
 def save(
     chart: Union[alt.TopLevelMixin, JSONDict],
-    fp: Optional[Union[IO, str]] = None,
+    fp: Optional[Union[IO, str, Path]] = None,
     fmt: Optional[str] = None,
     mode: Optional[str] = None,
     embed_options: Optional[JSONDict] = None,

--- a/altair_saver/_utils.py
+++ b/altair_saver/_utils.py
@@ -2,6 +2,7 @@ import contextlib
 from http import client
 import io
 import os
+from pathlib import Path
 import socket
 import subprocess
 import sys
@@ -135,7 +136,7 @@ def temporary_filename(
 @contextlib.contextmanager
 def maybe_open(fp: Union[IO, str], mode: str = "w") -> Iterator[IO]:
     """Context manager to write to a file specified by filename or file-like object"""
-    if isinstance(fp, str):
+    if isinstance(fp, (str, Path)):
         with open(fp, mode) as f:
             yield f
     elif isinstance(fp, io.TextIOBase) and "b" in mode:

--- a/altair_saver/_utils.py
+++ b/altair_saver/_utils.py
@@ -1,13 +1,13 @@
 import contextlib
-from http import client
 import io
 import os
-from pathlib import Path
 import socket
 import subprocess
 import sys
 import tempfile
-from typing import Callable, IO, Iterator, List, Optional, Union
+from http import client
+from pathlib import Path
+from typing import IO, Callable, Iterator, List, Optional, Union
 
 import altair as alt
 

--- a/altair_saver/savers/_saver.py
+++ b/altair_saver/savers/_saver.py
@@ -4,8 +4,13 @@ from pathlib import Path
 from typing import IO, Any, Dict, Iterable, List, Optional, Union
 
 import altair as alt
-from altair_saver._utils import (extract_format, fmt_to_mimetype,
-                                 infer_mode_from_spec, maybe_open)
+
+from altair_saver._utils import (
+    extract_format,
+    fmt_to_mimetype,
+    infer_mode_from_spec,
+    maybe_open,
+)
 from altair_saver.types import JSONDict, Mimebundle, MimebundleContent
 
 

--- a/altair_saver/savers/_saver.py
+++ b/altair_saver/savers/_saver.py
@@ -1,16 +1,12 @@
 import abc
 import json
-from typing import Any, Dict, IO, Iterable, List, Optional, Union
+from pathlib import Path
+from typing import IO, Any, Dict, Iterable, List, Optional, Union
 
 import altair as alt
-
-from altair_saver.types import Mimebundle, MimebundleContent, JSONDict
-from altair_saver._utils import (
-    extract_format,
-    fmt_to_mimetype,
-    infer_mode_from_spec,
-    maybe_open,
-)
+from altair_saver._utils import (extract_format, fmt_to_mimetype,
+                                 infer_mode_from_spec, maybe_open)
+from altair_saver.types import JSONDict, Mimebundle, MimebundleContent
 
 
 class Saver(metaclass=abc.ABCMeta):
@@ -91,7 +87,7 @@ class Saver(metaclass=abc.ABCMeta):
         return bundle
 
     def save(
-        self, fp: Optional[Union[IO, str]] = None, fmt: Optional[str] = None
+        self, fp: Optional[Union[IO, str, Path]] = None, fmt: Optional[str] = None
     ) -> Optional[Union[str, bytes]]:
         """Save a chart to file
 


### PR DESCRIPTION
I made a couple minor changes so that `pathlib.Path` can be passed into `save()`. The code below works, but I wasn't sure if/where to add it in tests since they use `io.StringIO` so don't write to an actual file.

```python
from pathlib import Path

import altair as alt
import pandas as pd

import altair_saver

data = pd.DataFrame({'a': list('CCCDDDEEE'),
                     'b': [2, 7, 4, 1, 2, 6, 8, 4, 7]})

chart = alt.Chart(data).mark_point().encode(
    x='a',
    y='b'
)
altair_saver.save(chart, "/tmp/chart.pdf")
altair_saver.save(chart, Path("/tmp/chart.pdf"))
```