### PR TITLE
untested code change to use find_element()

### DIFF
--- a/altair_saver/savers/_selenium.py
+++ b/altair_saver/savers/_selenium.py
@@ -264,7 +264,7 @@ class SeleniumSaver(Saver):
         driver.get("about:blank")
         driver.get(url)
         try:
-            driver.find_element_by_id("vis")
+            driver.find_element("id","vis")
         except NoSuchElementException:
             raise RuntimeError(f"Could not load {url}")
         if not self._offline:


### PR DESCRIPTION
See API docs here: https://www.selenium.dev/selenium/docs/api/py/index.html?highlight=find_element

and the [SO post](https://stackoverflow.com/questions/72773206/selenium-python-attributeerror-webdriver-object-has-no-attribute-find-el)

I'll have a quick look to see if there are any other changes.

Attempts to address #104