### PR TITLE
Update `npm` command to support version 9

### DIFF
--- a/altair_saver/savers/_node.py
+++ b/altair_saver/savers/_node.py
@@ -18,7 +18,7 @@ def npm_bin(global_: bool) -> str:
     npm = shutil.which("npm")
     if not npm:
         raise ExecutableNotFound("npm")
-    cmd = [npm, "bin"]
+    cmd = [npm, "root"]
     if global_:
         cmd.append("--global")
     return check_output_with_stderr(cmd).decode().strip()


### PR DESCRIPTION
NPM drops support for the `bin` command in version 9 ([ref here](https://docs.npmjs.com/cli/v7/commands/npm-bin?v=true)), while `root` is backwards compatible: [ref](https://docs.npmjs.com/cli/v9/commands/npm-root?v=true).